### PR TITLE
action: Workaround for git CVE-2022-24765

### DIFF
--- a/internal/githubaction/githubaction.go
+++ b/internal/githubaction/githubaction.go
@@ -149,6 +149,9 @@ func (c Command) run() []error {
 
 	pushURL := fmt.Sprintf("https://%s:%s@github.com/%s.git", ae.Actor, ae.Client.Token, ae.Repository)
 	err = c.execs([][]string{
+		// safe.directory workaround for CVE-2022-24765
+		// https://github.blog/2022-04-12-git-security-vulnerability-announced/
+		{"git", "config", "--global", "--add", "safe.directory", ae.Workspace},
 		{"git", "config", "--global", "user.name", userName},
 		{"git", "config", "--global", "user.email", userEmail},
 		{"git", "remote", "set-url", "--push", "origin", pushURL},


### PR DESCRIPTION
Hopefully fixes:
fatal: unsafe repository ('/github/workspace' is owned by someone else)

https://github.blog/2022-04-12-git-security-vulnerability-announced/