### PR TITLE
Update alpine from 3.16.1 to 3.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN cmd/bump/main_test.sh /bump
 
 # bump: alpine /FROM alpine:([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
-FROM alpine:3.16.1 AS bump-base
+FROM alpine:3.16.2 AS bump-base
 # git is used by github action code
 # curl for convenience
 RUN apk add --no-cache \


### PR DESCRIPTION
[Release notes](https://alpinelinux.org/posts/Alpine-3.16.2-released.html)  
