### PR TITLE
githubaction: Only include unique current versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wader/bump
 
-go 1.12
+go 1.18
 
 require (
 	// bump: semver /github.com\/Masterminds\/semver\/v3 v(.*)/ git:https://github.com/Masterminds/semver|^3

--- a/internal/githubaction/githubaction_test.go
+++ b/internal/githubaction/githubaction_test.go
@@ -14,6 +14,7 @@ func Test(t *testing.T) {
 		Currents: []bump.Current{
 			{Version: "1"},
 			{Version: "2"},
+			{Version: "2"},
 		},
 		Messages: []bump.CheckMessage{
 			{Message: "msg1 $NAME/$CURRENT/$LATEST"},
@@ -31,7 +32,7 @@ func Test(t *testing.T) {
 		template string
 		expected string
 	}{
-		{`Update {{.Name}} from {{join .Current ", "}} to {{.Latest}}`, `Update aaa from 1, 2 to 3`},
+		{`Update {{.Name}} to {{.Latest}} from {{join .Current ", "}}`, `Update aaa to 3 from 1, 2`},
 		{
 			`` +
 				`{{range .Messages}}{{.}}{{"\n\n"}}{{end}}` +

--- a/internal/slicex/slicex.go
+++ b/internal/slicex/slicex.go
@@ -1,0 +1,23 @@
+// slicex is package with generic slice functions
+package slicex
+
+func Map[F, T any](s []F, fn func(F) T) []T {
+	ts := make([]T, len(s))
+	for i, e := range s {
+		ts[i] = fn(e)
+	}
+	return ts
+}
+
+func Unique[T comparable](s []T) []T {
+	seen := map[T]struct{}{}
+	var us []T
+	for _, e := range s {
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		us = append(us, e)
+	}
+	return us
+}


### PR DESCRIPTION
Require go 1.18 to use generics
Refactor and add generic slice funtions package slicex

Fixes #100