### PR TITLE
semver: Don't sort versions when using template

### DIFF
--- a/internal/filter/semver/semver.go
+++ b/internal/filter/semver/semver.go
@@ -131,10 +131,8 @@ func (f semverFilter) Filter(versions filter.Versions, versionKey string) (filte
 			svs = append(svs, semverVersion{ver: ver, v: v})
 		}
 	}
-	sort.Slice(svs, func(i int, j int) bool {
-		return svs[i].ver.LessThan(svs[j].ver)
-	})
 
+	// if template assume input is already sorted etc
 	if f.template != "" {
 		var vs filter.Versions
 		for _, v := range svs {
@@ -142,6 +140,10 @@ func (f semverFilter) Filter(versions filter.Versions, versionKey string) (filte
 		}
 		return vs, versionKey, nil
 	}
+
+	sort.Slice(svs, func(i int, j int) bool {
+		return svs[i].ver.LessThan(svs[j].ver)
+	})
 
 	var latest *semverVersion
 	var latestIndex int

--- a/internal/pipeline/testdata/semver
+++ b/internal/pipeline/testdata/semver
@@ -25,3 +25,10 @@ n. -> error:no filter matches
 
 semver -> error:no filter matches
 semver: -> error:needs a contraint or version pattern argument
+
+n.n.n -> semver:n.n.n
+    4.5.6,1.2.3 -> 4.5.6,1.2.3 4.5.6
+    1.2.3,4.5.6 -> 1.2.3,4.5.6 1.2.3
+semver:n -> semver:n
+    4.5.6,1.2.3 -> 4,1 4
+    1.2.3,4.5.6 -> 1,4 1


### PR DESCRIPTION
Regression since #114. Before semver didnt keep lower versions so 'semver:*|n.n' would always giv n.n zero or one version at most so there was sort was a nop.

Related to #127