### PR TITLE
fetch: Identify as bump in user agent to be more friendly

### DIFF
--- a/internal/filter/fetch/fetch.go
+++ b/internal/filter/fetch/fetch.go
@@ -59,7 +59,12 @@ func (f fetchFilter) String() string {
 }
 
 func (f fetchFilter) Filter(versions filter.Versions, versionKey string) (filter.Versions, string, error) {
-	r, err := http.Get(f.urlStr)
+	req, err := http.NewRequest("GET", f.urlStr, nil)
+	req.Header.Add("User-Agent", "bump (https://github.com/wader/bump)")
+	if err != nil {
+		return nil, "", err
+	}
+	r, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
Hopefully fixes issue with some servers banning User-Agent: Go-http-client/1.1